### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ You can use them without providing API keys at app.reisearch.box or you can use 
 
 Everything is to be considered still in beta. Expect things to be added or changed with no warnings.
 
+<a href="https://glama.ai/mcp/servers/@0xReisearch/crypto-mcp-beta">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@0xReisearch/crypto-mcp-beta/badge" alt="REI Crypto Server MCP server" />
+</a>
+
 ## Current MCP servers:
 - DefiLlama Pro API
 - CoinGecko Pro API


### PR DESCRIPTION
This PR adds a badge for the [REI Crypto MCP Server](https://glama.ai/mcp/servers/@0xReisearch/crypto-mcp-beta) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@0xReisearch/crypto-mcp-beta">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@0xReisearch/crypto-mcp-beta/badge" alt="REI Crypto Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.